### PR TITLE
Allow overwriting answers

### DIFF
--- a/nodes/switch/switch.html
+++ b/nodes/switch/switch.html
@@ -14,6 +14,7 @@
             chatId: { value: "", required: false },
             question: { value: "" },
             answers: { value: [] },
+            answersOverride: { value: false, required: false },
             outputs: { value: 1 },
             autoAnswerCallback: { value: true, required: false },
             verticalAnswers: { value: false, required: false },
@@ -190,6 +191,10 @@
         </select>
     </div>
     <div class="form-row">
+        <label for="node-input-answersOverride">Overwrite Answer with <code>msg.answer</code></label>
+        <input type="checkbox" id="node-input-answersOverride" style="display:inline-block; width:auto; vertical-align:top;">
+    </div>
+    <div class="form-row">
         <label for="node-input-autoAnswerCallback">Auto-Answer</label>
         <input type="checkbox" id="node-input-autoAnswerCallback" style="display:inline-block; width:auto; vertical-align:top;">
     </div>
@@ -223,6 +228,9 @@
 
         <dt>Parse Mode <span class="property-type">enum</span></dt>
         <dd>How the Telegram client should parse the message. Can be plain text, <a href="https://core.telegram.org/bots/api/#markdown-style" target="_blank" rel="noopener noreferrer">Markdown</a>, <a href="https://core.telegram.org/bots/api/#markdownv2-style" target="_blank" rel="noopener noreferrer">MarkdownV2</a>, or <a href="https://core.telegram.org/bots/api/#html-style" target="_blank" rel="noopener noreferrer">HTML</a>.</dd>
+
+        <dt class="optional">Overwrite Answer <span class="property-type">boolean</span></label>
+        <dd>Overwrite Answer with <code>msg.answer</code>. Given content has to be an Array</dd>
 
         <dt class="optional">Auto-Answer <span class="property-type">list</span></dt>
         <dd>When enabled, automatically respond to the Telegram callback to resolve it as finished. Otherwise, you will have to send a payload to Telegram yourself to mark the request as complete.</dd>

--- a/nodes/switch/switch.js
+++ b/nodes/switch/switch.js
@@ -46,7 +46,7 @@ module.exports = function(RED) {
     }
 
     // Compute output ports
-    var portCount = (this.timeoutValue === null) ? this.answers.length : this.answers.length + 1;
+    var portCount = (this.answersOverride ? 1 : this.answers.length) + (this.timeoutValue === null ? 0 : 1);
     var ports = new Array(portCount);
 
     for (var i = 0; i < portCount; i++) {
@@ -61,17 +61,17 @@ module.exports = function(RED) {
 
       var chatId = node.chatId || msg.telegram.chat.id;
       var question = node.question || msg.payload;
-      var answers = node.answers || msg.answers || [];
       var answersOverride = node.answersOverride || false;
-
-      if (question && (answers.length > 0)) {
+      var answers = (node.answersOverride ? msg.answers : node.answers) || [];
+      
+      if (question && answers.length > 0) {
         var listener = function(botMsg){
           var username = botMsg.from.username;
           var fromChatId = botMsg.message.chat.id;
           var messageId = botMsg.message.message_id;
           var callbackQueryId = botMsg.id;
-
-          if (botMsg.data && fromChatId === chatId && messageId === msg.telegram.messageId) {
+          
+          if (botMsg.data && fromChatId == chatId && messageId == msg.telegram.messageId) {
             if (node.bot.isAuthorized(chatId, username)) {
               // Remove this listener since we got our reply
               node.telegramBot.removeListener("callback_query", listener);
@@ -102,19 +102,18 @@ module.exports = function(RED) {
               // Continue with the original message
               var outPorts = ports.slice(0);
               var outputPort = parseInt(botMsg.data);
-              if(answersOverride)
-                outputPort = 0;
               if(answersOverride){
-                msg.botMsg=botMsg;
-                node.send(msg);
+                  msg.payload = (msg.answers[botMsg.data].callback !== undefined ? msg.answers[botMsg.data].callback : msg.answers[botMsg.data]);
+                  msg.botMsg=botMsg;
+                  node.send(msg);
               }else{
-                if (!isNaN(outputPort) && outputPort < portCount) {
-                  outPorts[outputPort] = msg;
-                  node.send(outPorts);
-                } else {
-                  node.warn("invalid callback data received from telegram");
+                  if (!isNaN(outputPort) && outputPort < portCount) {
+                    outPorts[outputPort] = msg;
+                    node.send(outPorts);
+                  } else {
+                    node.warn("invalid callback data received from telegram");
+                  }
                 }
-              }
             } else {
               node.warn(`received callback in ${chatId} from '${username}' was unauthorized`);
             }
@@ -149,7 +148,7 @@ module.exports = function(RED) {
 
         var chunkSize = 4000;
         var answerOpts = answers.map(function(answer, idx){
-          var answer = { text: answer, callback_data: idx };
+          var answer = { text: (answersOverride && answer.text !== undefined ? answer.text : answer), callback_data: idx };
           return node.verticalAnswers ? [answer] : answer;
         });
         var options = {


### PR DESCRIPTION
Added suport for overwriting the answers with msg.answer. msg.answer could be an array like ["a","b","c"]. Then the value (a,b,c) will be the returned payload. It also could be [
{"text":"a", "callback":"cA"},
{"text":"b", "callback":"cB"},
{"text":"c", "callback":"cC"}
]
Then the callback will be returned.
In that case only one out node will be displayed, exceped when  timeout is enabled. In that case two nodes will be displayed.